### PR TITLE
Point to Music Blog on Subdomain

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -19,5 +19,5 @@ work:
   - name: Mixed Media
     link: /mixed_media/
   - name: Music Blog
-    link: http://kmagameguy.github.io
+    link: https://music.kmagameguy.com
     target: _blank


### PR DESCRIPTION
More tightly integrates the music blog (Kmagameguy/kmagameguy.github.io) with my main website.  Holding this PR until GitHub generates the HTTPS certs for the subdomain.