### PR TITLE
Use Patched Pages Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ source "https://rubygems.org"
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", github: "github/pages-gem", branch: "master", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,42 @@
-GIT
-  remote: https://github.com/github/pages-gem.git
-  revision: 46a24e9809b4eb25c8ce6c591b5168dd8a8b18c2
-  branch: master
+GEM
+  remote: https://rubygems.org/
   specs:
-    github-pages (213)
+    activesupport (6.0.3.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    autoprefixer-rails (9.8.6.5)
+      execjs
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.11.1)
+    colorator (1.1.0)
+    commonmarker (0.17.13)
+      ruby-enum (~> 0.5)
+    concurrent-ruby (1.1.8)
+    dnsruby (1.61.5)
+      simpleidn (~> 0.1)
+    em-websocket (0.5.2)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
+    eventmachine (1.2.7-x64-mingw32)
+    execjs (2.7.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    ffi (1.15.0-x64-mingw32)
+    forwardable-extended (2.6.0)
+    gemoji (3.0.1)
+    github-pages (214)
       github-pages-health-check (= 1.17.0)
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)
@@ -47,47 +80,6 @@ GIT
       nokogiri (>= 1.10.4, < 2.0)
       rouge (= 3.26.0)
       terminal-table (~> 1.4)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    activesupport (6.0.3.6)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    autoprefixer-rails (9.8.6.5)
-      execjs
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.11.1)
-    colorator (1.1.0)
-    commonmarker (0.17.13)
-      ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.8)
-    dnsruby (1.61.5)
-      simpleidn (~> 0.1)
-    em-websocket (0.5.2)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
-    eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
-    execjs (2.7.0)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday-net_http (1.0.1)
-    ffi (1.15.0)
-    ffi (1.15.0-x64-mingw32)
-    forwardable-extended (2.6.0)
-    gemoji (3.0.1)
     github-pages-health-check (1.17.0)
       addressable (~> 2.3)
       dnsruby (~> 1.60)
@@ -225,8 +217,6 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.11.2-x64-mingw32)
       racc (~> 1.4)
-    nokogiri (1.11.2-x86_64-linux)
-      racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -265,7 +255,6 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
     unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
@@ -273,10 +262,9 @@ GEM
 
 PLATFORMS
   x64-mingw32
-  x86_64-linux
 
 DEPENDENCIES
-  github-pages!
+  github-pages
   jekyll-autoprefixer
   jekyll-feed (~> 0.12)
   jekyll-paginate


### PR DESCRIPTION
Effectively reverts #18. Github finally published an updated pages-gem which contains a patch for the kramdown vulnerability identified last week. This re-points the repo to the gem rather than the patch commit.