### PR TITLE
Make Images Scale Responsively for Better Mobile Experience

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -29,6 +29,8 @@ h1, h2, h3, h4, h5, h6, .navbar {
 
 img {
   border-radius: 0.2rem;
+  max-width: 100%;
+  height: auto;
 }
 
 .img-left {


### PR DESCRIPTION
Noticed while browsing via my phone the other night that images break through their containers.  This fixes that so they scale responsively, as needed by the browser dimensions.

This scss file is probably overdue for a clean-up at some point, but for now I just wanted to get things looking right.