### PR TITLE
Update Dependencies for Ruby 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.2)
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (9.8.6.5)
       execjs
@@ -247,7 +247,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.2)
+    tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -274,4 +274,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.7
+   2.4.10


### PR DESCRIPTION
- Ruby 3.2.2
- Bundler 2.4.10
- addressable 2.8.2
- tzinfo-data 1.2023.3